### PR TITLE
Fix: Signature image resize

### DIFF
--- a/src/main/java/com/github/adrianjesussilva/textimageforge/logic/image/ImageForge.java
+++ b/src/main/java/com/github/adrianjesussilva/textimageforge/logic/image/ImageForge.java
@@ -118,7 +118,15 @@ public class ImageForge {
 		}
 		
 		if(signatureWidth != null && signatureHeight!=null) {
-			height +=  (int)((this.width-(leftMargin + rightMargin))*0.5*signatureHeight)/(signatureWidth) + 40;
+			
+			//Avoid oversizing small images that don't requiere a strech
+			double safeZoneWidth = (this.width-(leftMargin + rightMargin))*0.5;
+			if ((int) safeZoneWidth <= signatureWidth) {
+				height +=  (int)(safeZoneWidth*signatureHeight)/(signatureWidth) + 40;
+			}
+			else {
+				height +=  (int)(signatureHeight) + 40;
+			}
 		}
 			
 		
@@ -234,7 +242,12 @@ public class ImageForge {
 
 			BufferedImage voucher = getBufferedImage();
 			
-			signatureImg = overlay.resizeImage(signatureImg, (int) ((int)(this.width-(leftMargin + rightMargin))*0.5), (int)((this.width-(leftMargin + rightMargin))*0.5*signatureImg.getHeight())/signatureImg.getWidth());
+			//Avoid oversizing small images that don't requiere a strech
+			double safeZoneWidth = (this.width-(leftMargin + rightMargin))*0.5;
+			
+			if ((int) safeZoneWidth <= signatureImg.getWidth()) {
+				signatureImg = overlay.resizeImage(signatureImg, (int) (safeZoneWidth), (int)(safeZoneWidth*signatureImg.getHeight())/signatureImg.getWidth());
+			}
 			
 			this.height = this.height + signatureImg.getHeight();
 			

--- a/src/test/java/com/github/adrianjesussilva/textimageforge/TestImageForge.java
+++ b/src/test/java/com/github/adrianjesussilva/textimageforge/TestImageForge.java
@@ -21,6 +21,7 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.xml.bind.DatatypeConverter;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -205,6 +206,49 @@ log.info("Starting Dynamic Size Image");
 
 		
 		log.info("Ending Dynamic Size Image");
+	}
+	
+	@Test
+	@DisplayName("Test 04 Dynamic Size Image with Signature")
+	void test04DynamicSizeImage () {
+		
+		int voucherHeight = 70;
+		int voucherWidth = 120;
+		
+		//Vertical image 20 x 90
+		String signature = "iVBORw0KGgoAAAANSUhEUgAAABQAAABaCAIAAAA3ueFGAAAAAXNSR0IArs4c6QAAAANzQklUCAgI2+FP4AAAAvxJREFUWIXtl7tS3DAUhn+Z9GiTmsFUSRNmlTegzZICymQnyVDzCJ5J8gA8AlTUa2YYSqioodra+wKJvH3ik0JrcSzrYjZDKv5qJevzOT4XSQsarKIowFQURYZ/0DP8DD/D/xkmovVhIYT9PZ/P+eRoNHqE2/f399YdIYRSCsndp2kaItJaO440TZO2bABj1oZAKSWEGOr2zc0NH+7u7mLtVG1tba0PG6XhSKqHBmw+n/NQG71IwgDKsizLks+MRqOVV3FprTc3N7kjUkqtNRGl4ePjY8eR2WxmHqXhPM85eXBwYB8l4KqqHLPGYaNgtInIeMgnlVJSSjsMwiYxWmueoclkwtc8cZFE9JRwvyQfAUc+OAYbbLlcWvt9LxKpury8tC8iolU/cAshORUCoKoqviAGHx4ecpJXdQLuV3VZlh7Y7MyOTk5OOJnneX9N5g0jgNvbW/5oOp16ohpy23SPhe/u7vpr/LA9loyklN5l/jxfX1/z4d7enneZCxMRgLquBTLRPn3z9vUf/E7D8U5w5N+3hRCEJgn7v5mizZSAByqjtmPWgUO92rWQZT4f/W7bi0/Ccn+qLMuLiws+81K+El4zTsU5ZyIAeyama9vpRACz2czbsx5YKcXJ/u4RhPu7x2KxiMCZ/XJ0z0QhxHg83t7eTkfb5PlX/RNtvgk0+fA+QuIJzypqa5YCxduBnSK1w1DxZp23NgLtSECI8KVjBYfeGnK1A/PB1dUVH7rHmteCrRDHC1shofJ8sGzudXbIKyQYMPvL/Iuw2t/fT/js5lngocJEk9xAPcmIbElOCjywWdGIpulZdt6buNDE1YUJov3oDWzYHTNR23Vdn5+fh9YlUnV2drZYLPiD4I7pwNT+VbTa2dk5OjqKkyvY7URg+vETv5TH4LWVgUXLiABkg474DMDp6akTrSE+P1jmU3meD4kWAFRV5dgpiiKy0Xf6+ce378uu5YE+A50uXPkcOhP7wtfPXywspfReE4PwUtfvxgqAUsq5iyf1FytwXKrys4/uAAAAAElFTkSuQmCC";		
+		
+		int signatureOriginalHeight = 90;
+		int signatureTopPadding = 40;
+		
+		ImageForge iForge = ImageForge.builder()
+				.height(voucherHeight)
+				.width(voucherWidth)
+				.superiorMargin(15)
+				.leftMargin(15)
+				.inferiorMargin(15)
+				.rightMargin(15)
+				.lineSpacing(2)
+				.build();
+		
+		assertDoesNotThrow(() -> iForge.addLine("   TEST 04"), "It should not produce a exception");
+		
+		BufferedImage image = null;
+		try {
+			image = iForge.forgeImage(ImageEncoder.jpg, signature);
+		} catch (IOException | InvalidTextForgeConfigException e) {
+			fail ("it should not produce a exception");
+		}
+		assertNotNull(image);
+		
+		//Signature should not be resized if signature width is less than voucher width 
+		Assertions.assertTrue(image.getHeight() <= voucherHeight + signatureOriginalHeight + signatureTopPadding, "The resulting image has height greater than expected.");
+		
+		//Width should not change
+		Assertions.assertEquals(voucherWidth, image.getWidth());
+		
+		log.info("Ending Dynamic Size Image");
+		
 	}
 
 }

--- a/src/test/java/com/github/adrianjesussilva/textimageforge/TestSignatureOverlay.java
+++ b/src/test/java/com/github/adrianjesussilva/textimageforge/TestSignatureOverlay.java
@@ -127,5 +127,20 @@ class TestSignatureOverlay {
 		assertDoesNotThrow(() -> voucherImage(fileName,voucherLines , null));
 		log.info("Ending validation of voucher generation");
 	}
+	
+	/**
+	 * Test to validate image generation with signature smaller than voucher width
+	 */
+	@Test
+	@DisplayName("Test 02 Validation test with small signature")
+	void test02ValidationTest () {
+		log.info("Starting validation of voucher generation with small signature");
+		String fileName = "voucher-small-signature";
+		String signature = "iVBORw0KGgoAAAANSUhEUgAAABQAAABaCAIAAAA3ueFGAAAAAXNSR0IArs4c6QAAAANzQklUCAgI2+FP4AAAAvxJREFUWIXtl7tS3DAUhn+Z9GiTmsFUSRNmlTegzZICymQnyVDzCJ5J8gA8AlTUa2YYSqioodra+wKJvH3ik0JrcSzrYjZDKv5qJevzOT4XSQsarKIowFQURYZ/0DP8DD/D/xkmovVhIYT9PZ/P+eRoNHqE2/f399YdIYRSCsndp2kaItJaO440TZO2bABj1oZAKSWEGOr2zc0NH+7u7mLtVG1tba0PG6XhSKqHBmw+n/NQG71IwgDKsizLks+MRqOVV3FprTc3N7kjUkqtNRGl4ePjY8eR2WxmHqXhPM85eXBwYB8l4KqqHLPGYaNgtInIeMgnlVJSSjsMwiYxWmueoclkwtc8cZFE9JRwvyQfAUc+OAYbbLlcWvt9LxKpury8tC8iolU/cAshORUCoKoqviAGHx4ecpJXdQLuV3VZlh7Y7MyOTk5OOJnneX9N5g0jgNvbW/5oOp16ohpy23SPhe/u7vpr/LA9loyklN5l/jxfX1/z4d7enneZCxMRgLquBTLRPn3z9vUf/E7D8U5w5N+3hRCEJgn7v5mizZSAByqjtmPWgUO92rWQZT4f/W7bi0/Ccn+qLMuLiws+81K+El4zTsU5ZyIAeyama9vpRACz2czbsx5YKcXJ/u4RhPu7x2KxiMCZ/XJ0z0QhxHg83t7eTkfb5PlX/RNtvgk0+fA+QuIJzypqa5YCxduBnSK1w1DxZp23NgLtSECI8KVjBYfeGnK1A/PB1dUVH7rHmteCrRDHC1shofJ8sGzudXbIKyQYMPvL/Iuw2t/fT/js5lngocJEk9xAPcmIbElOCjywWdGIpulZdt6buNDE1YUJov3oDWzYHTNR23Vdn5+fh9YlUnV2drZYLPiD4I7pwNT+VbTa2dk5OjqKkyvY7URg+vETv5TH4LWVgUXLiABkg474DMDp6akTrSE+P1jmU3meD4kWAFRV5dgpiiKy0Xf6+ce378uu5YE+A50uXPkcOhP7wtfPXywspfReE4PwUtfvxgqAUsq5iyf1FytwXKrys4/uAAAAAElFTkSuQmCC";
+		String [] voucherLines={"","        VOUCHER 2 "," ", "this is a voucher"};
+		assertDoesNotThrow(() -> voucherImage(fileName,voucherLines , signature));
+		
+		log.info("Ending validation of voucher generation");
+	}
 
 }


### PR DESCRIPTION
### Description
The changes made to the Text To Image Forge library addresses an issue with signatures with a width less than the original voucher. This conditions lead to the signature to be upscale until signature and voucher matched.

### Changes
Changes were made in order to evalute if a signature resizing is required by comparing the desired value and the signature's.

Also the desired width used during for the resizing was copied to a variable named `safeZoneWidth` to improve readibility of code during height operations.

### Testing
The TestSignatureOverlay file contains a few unit tests of the changes made within the library, can be run on preferred IDE using JUnit, we recommend using Eclipse IDE.

Validation for the undesired behaviour was added on the `TestImageForge.java` class where the resulting height was greater than expected.

And results of `TestSignatureOverlay.java` before and after the changes can be compared below.

**After changes:**
![voucher-small-signature](https://github.com/AdrianJesusSilva/TextToImageForge/assets/32227166/19eb6acb-bfb2-4ca9-b1ac-10d928f0c04d)

**Before changes:**
![unexpected-voucher-small-signature](https://github.com/AdrianJesusSilva/TextToImageForge/assets/32227166/ce8dcf47-be02-424f-8860-3465629b0752)



